### PR TITLE
feat: add support for specifying a host for the server

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import { URL } from 'url';
 interface Config {
   buildApp?: () => Koa;
   port?: number;
+  host?: string;
 }
 
 type Path = string | RegExp;
@@ -35,7 +36,7 @@ export class MockServer {
       server
         .on('error', reject)
         .on('listening', resolve)
-        .listen({ port: this.config.port || 0 })
+        .listen({ port: this.config.port || 0, host: this.config.host })
     );
 
     this.server = server;


### PR DESCRIPTION
This simply exposes one more configuration from the underlying http server, the "host". This allows me to listen in specific IP addresses for my use-case.

I didn't know how to easily write tests for this. Even though I am using this on multiple IPs in my own tests, that is in a docker environment where I can add/remove IPs from my container.